### PR TITLE
0.11.1 - Fix serialization of dicts and list of dicts resulting in empty dicts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+source = knockout_modeler
+omit =
+    */tests*

--- a/knockout_modeler/templatetags/knockout.py
+++ b/knockout_modeler/templatetags/knockout.py
@@ -1,12 +1,12 @@
 from django import template
 try:
     import simplejson as json
-except ImportError, e:
+except ImportError as e:
     import json
-import datetime
 from knockout_modeler.ko import ko, ko_data, ko_model, ko_bindings, get_fields
 
 register = template.Library()
+
 
 def knockout(values):
     """
@@ -15,9 +15,10 @@ def knockout(values):
 
     if not values:
         return ''
-        
+
     field_names = get_fields(values[0])
     return ko(values, field_names)
+
 
 def knockout_data(values, args=None):
     """
@@ -40,6 +41,7 @@ def knockout_data(values, args=None):
     field_names = get_fields(values[0])
     return ko_data(values, field_names, name, safe)
 
+
 def knockout_model(values):
     """
 
@@ -51,6 +53,7 @@ def knockout_model(values):
     modelClass = values[0].__class__
     return ko_model(modelClass, field_names)
 
+
 def knockout_bindings(values):
     """
 
@@ -59,6 +62,7 @@ def knockout_bindings(values):
         return ''
 
     return ko_bindings(values[0])
+
 
 register.filter(knockout)
 register.filter(knockout_data)

--- a/knockout_modeler/tests.py
+++ b/knockout_modeler/tests.py
@@ -3,22 +3,23 @@ Simple tests for Django Knockout Modeler.
 
 """
 
-from django.conf import settings
+import json
+import uuid
+
+import js2py
 from django.db import models
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django_fake_model import models as f
 
 from knockout_modeler.ko import get_fields
-from knockout_modeler.ko import ko_model
-from knockout_modeler.ko import ko_bindings
-from knockout_modeler.ko import ko_json
-from knockout_modeler.ko import ko_data
+from knockout_modeler.ko import get_object_data
 from knockout_modeler.ko import ko
-
+from knockout_modeler.ko import ko_bindings
+from knockout_modeler.ko import ko_data
+from knockout_modeler.ko import ko_json
+from knockout_modeler.ko import ko_model
 from knockout_modeler.templatetags import knockout
 
-import json
-import js2py
 
 ######
 #  Fake Testing Models
@@ -26,20 +27,23 @@ import js2py
 
 class Profession(f.FakeModel):
     title = models.CharField('Title', max_length=200, blank=True)
-    skill = models.IntegerField('Skill', default=0)  
+    skill = models.IntegerField('Skill', default=0)
 
     class Meta:
-        app_label = 'test'  
+        app_label = 'test'
+
 
 class HomeCity(f.FakeModel):
     name = models.CharField('Name', max_length=200, blank=True)
-    population = models.IntegerField('Skill', default=0)    
+    population = models.IntegerField('Skill', default=0)
 
     class Meta:
-        app_label = 'test'  
+        app_label = 'test'
 
-    def knockout_fields(self):
+    @staticmethod
+    def knockout_fields():
         return ['name']
+
 
 class Person(f.FakeModel):
     first_name = models.CharField('First Name', max_length=200, blank=True)
@@ -50,25 +54,23 @@ class Person(f.FakeModel):
     home_city = models.ForeignKey(HomeCity, blank=True)
 
     class Meta:
-        app_label = 'test'  
-
-    def knockout_fields(self):
-        return [
-                    'first_name', 
-                    'home_city',
-                    'profession'
-                ]
+        app_label = 'test'
 
     @classmethod
-    def comparator(self):
+    def comparator(cls):
         return 'uuid'
+
+    @staticmethod
+    def knockout_fields():
+        return ['first_name', 'home_city', 'profession']
 
 ####
 # The actual tests
 ####
 
-class KnockoutTests(TestCase):
-    
+
+class KnockoutTests(TransactionTestCase):
+
     def setup_user(self):
 
         rapper = Profession()
@@ -84,7 +86,7 @@ class KnockoutTests(TestCase):
         wayne = Person()
         wayne.first_name = 'Lil'
         wayne.last_name = 'Wayne'
-        wayne.uuid = 'dead-beef'
+        wayne.uuid = uuid.uuid4()
         wayne.profession = rapper
         wayne.home_city = no
         wayne.save()
@@ -113,6 +115,83 @@ class KnockoutTests(TestCase):
     @Profession.fake_me
     @HomeCity.fake_me
     @Person.fake_me
+    def test_get_object_data(self):
+        """
+        Tests get_object_data
+        """
+
+        # Test a regular model
+        wayne = self.setup_user()
+        fields = get_fields(wayne)
+        expected = {
+            'first_name': 'Lil',
+            'home_city': {'name': 'New Orleans'},
+            'profession': {'skill': 999, u'id': 1, 'title': 'Rapper'},
+        }
+        actual = get_object_data(wayne, fields, safe=False)
+        self.assertEqual(actual, expected)
+
+        # Test a model with a dict
+        wayne = self.setup_user()
+        expected = {
+            'first_name': 'Lil',
+            'home_city': {'name': 'New Orleans'},
+            'home_city_dict': {'name': 'New Orleans'},
+            'profession': {'skill': 999, u'id': 2, 'title': 'Rapper'},
+            'profession_dict': {'skill': 999, u'id': 2, 'title': 'Rapper'},
+        }
+        wayne.home_city_dict = expected['home_city']
+        wayne.profession_dict = expected['profession']
+        new_fields = ['home_city_dict', 'profession_dict']
+        actual = get_object_data(wayne, fields + new_fields, safe=False)
+        self.assertEqual(actual, expected)
+
+        # Test a model with a list of dicts
+        wayne = self.setup_user()
+        expected = {
+            'first_name': 'Lil',
+            'home_city': {'name': 'New Orleans'},
+            'profession': {'skill': 999, u'id': 3, 'title': 'Rapper'},
+            'list_of_dicts': [
+                {'name': 'New Orleans'},
+                {'skill': 999, u'id': 3, 'title': 'Rapper'},
+            ],
+        }
+        wayne.list_of_dicts = [expected['home_city'], expected['profession']]
+        new_fields = ['list_of_dicts']
+        actual = get_object_data(wayne, fields + new_fields, safe=False)
+        self.assertEqual(actual, expected)
+
+        # Test a model with a list of models
+        wayne = self.setup_user()
+        expected = {
+            'first_name': 'Lil',
+            'home_city': {'name': 'New Orleans'},
+            'profession': {'skill': 999, u'id': 4, 'title': 'Rapper'},
+            'list_of_models': [{
+                'first_name': 'Lil',
+                'home_city': {'name': 'New Orleans'},
+                'profession': {'skill': 999, u'id': 5, 'title': 'Rapper'},
+            }],
+        }
+        wayne.list_of_models = [self.setup_user()]
+        new_fields = ['list_of_models']
+        actual = get_object_data(wayne, fields + new_fields, safe=False)
+        self.assertEqual(actual, expected)
+
+        # Test with safe=True and some existing and non-existing fields
+        wayne = self.setup_user()
+        fields = ['first_name', 'home_city', 'non-existent']
+        expected = {
+            'first_name': 'Lil',
+            'home_city': {'name': 'New Orleans'},
+        }
+        actual = get_object_data(wayne, fields, safe=True)
+        self.assertEqual(actual, expected)
+
+    @Profession.fake_me
+    @HomeCity.fake_me
+    @Person.fake_me
     def test_ko_model(self):
         """
         Tests ko_model
@@ -136,7 +215,7 @@ class KnockoutTests(TestCase):
 
         wayne = self.setup_user()
         bindings = ko_bindings(wayne)
-        self.assertNotEqual(ko_bindings, '')
+        self.assertNotEqual(bindings, '')
 
     @Profession.fake_me
     @HomeCity.fake_me
@@ -194,7 +273,7 @@ class KnockoutTests(TestCase):
         self.assertEqual(data, '[]')
         interpreted = js2py.eval_js(data)
 
-        # Test an invididual object
+        # Test an individual object
         rapper = wayne.profession
         data = ko_data(rapper)
         self.assertNotEqual(data, '[]')

--- a/manage.py
+++ b/manage.py
@@ -7,17 +7,4 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
-    is_testing = 'test' in sys.argv
-
-    if is_testing:
-        import coverage
-        cov = coverage.coverage(source=['knockout_modeler'], omit=['*/tests/*'])
-        cov.erase()
-        cov.start()
-
     execute_from_command_line(sys.argv)
-
-    if is_testing:
-        cov.stop()
-        cov.save()
-        cov.report()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage>=4.0.2
-Django>=1.11
+Django>=1.8
 django-fake-model>=0.1.1
 Js2Py>=0.30
 nose>=1.3.7

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Set external files
 try:
     from pypandoc import convert
-    README = convert('README.md', 'rst')	 
+    README = convert('README.md', 'rst')
 except ImportError:
     README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
     print("warning: pypandoc module not found, could not convert Markdown to RST")
@@ -17,7 +17,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-knockout-modeler',
-    version='0.11.0',
+    version='0.11.1',
     packages=['knockout_modeler'],
     install_requires=required,
     include_package_data=True,

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,2 @@
 #! /bin/sh
-python manage.py test
+coverage run manage.py test && coverage report


### PR DESCRIPTION
Please see inline comments for annotations.

Other minor changes:
- Import optimizations, autopep8
- Test coverage runs pulled out from `manage.py` into `test.sh` file with config specified in `.coveragerc`